### PR TITLE
Die with the correct exit status.

### DIFF
--- a/lib/Child.pm
+++ b/lib/Child.pm
@@ -70,8 +70,10 @@ sub start {
     my $code = $self->code;
 
     # Ensure the child code can't die and jump out of our control.
-    eval { $code->( $parent ); } || do {
+    eval { $code->( $parent ); 1; } || do {
+        # Simulate die without dying.
         print STDERR $@;
+        exit 255;
     };
     exit;
 }

--- a/t/die.t
+++ b/t/die.t
@@ -15,6 +15,7 @@ note "die in child"; {
         my $child = Child->new(sub { die "Foo\n" });
         my $proc = $child->start;
         $proc->wait;
+        is $proc->exit_status, 255;
     }, "Foo\n";
 
     is $pid, $$, "didn't leak out of the child process";
@@ -28,9 +29,24 @@ note "Child in eval"; {
             my $child = Child->new(sub { die "Foo\n" });
             my $proc = $child->start;
             $proc->wait;
+            is $proc->exit_status, 255;
         };
         is $@, '', "child death does not affect parent \$@";
     }, "Foo\n";
+
+    is $pid, $$, "didn't leak out of the child process";
+};
+
+
+note "Function returning false isn't confused with dying"; {
+    my $pid = $$;
+
+    is capture_stderr {
+        my $child = Child->new(sub { return });
+        my $proc = $child->start;
+        $proc->wait;
+        is $proc->exit_status, 0;
+    }, "";
 
     is $pid, $$, "didn't leak out of the child process";
 };


### PR DESCRIPTION
Also fix child functions returning false being confused with dying.

Fixes the problems introduced by #8.
