### PR TITLE
dist.ini: fix bugtracker.web and repository.url links

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,8 +14,8 @@ copyright_holder = Chad Granum
 [TestRelease]
 
 [MetaResources]
-bugtracker.web  = http://github.com/Test-More/Child/issues
-repository.url  = http://github.com/Test-More/Child/
+bugtracker.web  = http://github.com/exodist/Child/issues
+repository.url  = http://github.com/exodist/Child
 repository.type = git
 
 [Prereqs]


### PR DESCRIPTION
Hi Chad

This is a very easy fix to correct the metadata in the dist.ini file. Right now, the bug tracker link at  https://metacpan.org/pod/Child points to a wrong URL and this commit fixes it.