### PR TITLE
Add basic TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+language: perl
+perl:
+   - 'blead'
+   - '5.20'
+   - '5.18'
+   - '5.16'
+   - '5.14'
+   - '5.12'
+   - '5.10'
+   - '5.8'
+matrix:
+   allow_failures:
+      - perl: 'blead'
+      - perl: '5.8'
+   fast_finish: true
+before_install:
+   - git config --global user.name "TravisCI"
+   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
+install:
+   - cpanm --quiet --notest --skip-satisfied Dist::Zilla
+   - "dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest"
+   - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose"
+script:
+   - dzil smoke --release --author

--- a/dist.ini
+++ b/dist.ini
@@ -32,6 +32,8 @@ Capture::Tiny = 0.22
 [MetaYAML]
 [MetaJSON]
 
+[TravisYML]
+
 [Git::Check]
 [Git::Commit]
 [Git::Tag]


### PR DESCRIPTION
This gets us working on TravisCI!
https://travis-ci.org/exodist/Child/builds/139363199

Might want to turn on Git::CommitBuild later to avoid having to install all the dzil stuff for every single test run. Also some dzil deps don't appear to work on 5.8.