### PR TITLE
Use AppveyorCI

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -46,10 +46,6 @@
 \bbuild.com$
 ^MANIFEST\.SKIP
 
-.travis.yml
-
-dist.ini
-
 test.pl
 
 # Avoid Devel::Cover stuff
@@ -65,8 +61,9 @@ test.pl
 # The extra tests are for dist author testing only
 \bxt
 
-# For github testing
+# CI configs
 .travis.yml
+appveyor.yml
 
 dist.ini
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+skip_tags: true
+
+cache:
+  - C:\strawberry
+
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --installdeps .
+
+build_script:
+  - perl -e 1
+
+test_script:
+  - prove -lr
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - dzil listdeps --missing | cpanm
 
 build_script:
-  - perl -e 1
+  - perl -e 2
 
 test_script:
   - dzil test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,12 @@ install:
   - if not exist "C:\strawberry" cinst strawberryperl
   - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
   - cd C:\projects\%APPVEYOR_PROJECT_NAME%
-  - cpanm --installdeps .
+  - cpanm -n Dist::Zilla
+  - dzil authordeps --missing | cpanm -n
+  - dzil listdeps --missing | cpanm
 
-build_script:
-  - perl -e 1
+build: off
 
 test_script:
-  - prove -lr
+  - dzil test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ install:
   - dzil authordeps --missing | cpanm -n
   - dzil listdeps --missing | cpanm
 
-build: off
+build_script:
+  - perl -e 1
 
 test_script:
   - dzil test

--- a/dist.ini
+++ b/dist.ini
@@ -25,7 +25,7 @@ Exporter = 5.57
 
 [Prereqs / TestRequires]
 Test::More    = 0.88
-Capture::Tiny = 0.22
+Capture::Tiny = 0.31
 
 [MakeMaker]
 [CPANFile]


### PR DESCRIPTION
This gets Child working on Appveyor.
https://ci.appveyor.com/project/exodist/child/build/1.0.4

It also fixes a bug in t/die.t with Perl on Windows <= 5.20 (Appveyor is using 5.20.1). That will be a very welcome fix for perl5i!

Unlike Travis, Appveyor caches the build so it would benefit less from using the dzil Git::CommitBuild plugin.
